### PR TITLE
SHIP-0038: Release Branch Workflows

### DIFF
--- a/.github/workflows/release-branch.yml
+++ b/.github/workflows/release-branch.yml
@@ -1,0 +1,25 @@
+# Reusable release brancher workflow
+# See SHIP-0038: https://github.com/shipwright-io/community/pull/194
+name: Release Brancher
+on:
+  workflow_call:
+    inputs:
+      release-version:
+        required: true
+        type: string
+      git-ref:
+        required: false
+        type: string
+jobs:
+  release-brancher:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.git-ref }}
+    - name: Create release branch
+      env:
+        RELEASE_VERSION: release-${{ inputs.release-version }}
+      run: |
+        git switch -c "${RELEASE_VERSION}"
+        git push --set-upstream origin "${RELEASE_VERSION}"

--- a/workflow-templates/release-branch.properties.json
+++ b/workflow-templates/release-branch.properties.json
@@ -1,0 +1,8 @@
+{
+    "name": "adambkaplan Release Brancher",
+    "description": "Starter workflow for creating release branches",
+    "iconName": "octicon git-branch",
+    "categories": [
+        "Automation"
+    ]
+}

--- a/workflow-templates/release-branch.properties.json
+++ b/workflow-templates/release-branch.properties.json
@@ -1,5 +1,5 @@
 {
-    "name": "adambkaplan Release Brancher",
+    "name": "Release Brancher",
     "description": "Starter workflow for creating release branches",
     "iconName": "octicon git-branch",
     "categories": [

--- a/workflow-templates/release-branch.yml
+++ b/workflow-templates/release-branch.yml
@@ -1,0 +1,23 @@
+# Release branch starter workflow
+# See SHIP-0038: https://github.com/shipwright-io/community/pull/194
+name: Create Release Branch
+on:
+  workflow_dispatch:
+    inputs:
+      release-version:
+        required: true
+        type: string
+        description: "Semantic version for the release branch (vX.Y format)"
+      git-ref:
+        required: false
+        type: string
+        description: "Git ref to create the release branch from (defaults to main)"
+        default: "main"
+jobs:
+  create-release-branch:
+    permissions:
+      contents: write
+    uses: shipwright-io/.github/.github/workflows/release-branch.yml@main
+    with:
+      release-version: ${{ inputs.release-version }}
+      git-ref: ${{ inputs.git-ref }}

--- a/workflow-templates/release-branch.yml
+++ b/workflow-templates/release-branch.yml
@@ -9,7 +9,7 @@ on:
         type: string
         description: "Semantic version for the release branch (vX.Y format)"
       git-ref:
-        required: false
+        required: true
         type: string
         description: "Git ref to create the release branch from (defaults to main)"
         default: "main"


### PR DESCRIPTION
# Changes

Creating a reusable GitHub Actions workflow to set up release branches in Shipwright projects, and a corresponding starter workflow template. These workflows will let Shipwright projects opt into setting up release branches for project artifacts. The workflows allow branches to be created at specific git references, allowing release branches to be set up retroactively.

Partially implements shipwright-io/community#85 
Proposal PR: shipwright-io/community#194


# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
