### PR TITLE
Fix redirection for Code Of Conduct

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ By submitting pull requests submitters acknowledge they grant the
 
 ## Getting Started
 
-All contributors must abide by our [Code of Conduct](/code-of-conduct.md).
+All contributors must abide by our [Code of Conduct](/CODE_OF_CONDUCT.md).
 
 The core code for Shipwright is located in the following repositories:
 


### PR DESCRIPTION
# Changes

Fix the redirection to `CODE_OF_CONDUCT.md` inside the `CONTRIBUTING.md` file, which was not working because the file name was written in lowercase

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
