### PR TITLE
Fix contributor guide link in PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -18,7 +18,7 @@ Fixes #<insert issue number here>
 - [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
 - [ ] Release notes block has been filled in, or marked NONE
 
-See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
+See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
 for details on coding conventions, github and prow interactions, and the code review process.
 
 # Release Notes


### PR DESCRIPTION
# Changes

Fixes https://github.com/shipwright-io/build/issues/2060

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
