### PR TITLE
fix: Complete mailing list migration to lists.cncf.io domain

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/shipwright-io/community/discussions
     about: Join in-depth discussions about everything Shipwright, propose new features, debate to your hearts content, and help shape our future!
   - name: Mailing Lists
-    url: https://lists.shipwright.io
+    url: https://lists.cncf.io
     about: Do you love your email client and want to spend more time using it? Then this is the place for you! Ask questions and get announcements all from the safety of your inbox.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,9 +94,9 @@ Once the pull request is approved and marked "lgtm", it will get merged.
 We run the community meetings every Monday at 13:00 UTC time.
 For each upcoming meeting we generate a new issue where we layout the topics to discuss.
 See our [previous meetings](https://github.com/shipwright-io/build/issues?q=is%3Aissue+label%3Acommunity+is%3Aclosed) outcomes.
-Please request an invite in our Slack [channel](https://kubernetes.slack.com/archives/C019ZRGUEJC) or join the [shipwright-dev mailing list](https://lists.shipwright.io/admin/lists/shipwright-users.lists.shipwright.io/).
+Please request an invite in our Slack [channel](https://kubernetes.slack.com/archives/C019ZRGUEJC) or join the [shipwright-dev mailing list](https://lists.cncf.io/g/shipwright-dev).
 
-All meetings are also published on our [public calendar](https://calendar.google.com/calendar/embed?src=shipwright-admin%40lists.shipwright.io&ctz=America%2FNew_York).
+All meetings are also published on our [public calendar](https://zoom-lfx.platform.linuxfoundation.org/meetings/shipwright?view=week).
 
 ## Contact Information
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,5 +9,5 @@ To report a vulnerability via GitHub issues, click on the `Issues` tab at the to
 
 ### Report using email
 
-To report a vulnerability via email, send an email to shipwright-security@lists.shipwright.io.
+To report a vulnerability via email, send an email to shipwright-security@lists.cncf.io.
 Encryption using GPG is NOT required to make a disclosure.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -24,7 +24,8 @@ Join in-depth discussions about Shipwright, propose new features, debate to your
 
 Do you love your email client and want to spend more time using it? Then this is the place for you! Ask questions and get announcements all from the safety of your inbox.
 
-[Join the Community](https://lists.shipwright.io)
+- User mailing list - [shipwright-users@lists.cncf.io](https://lists.cncf.io/g/shipwright-users/join)
+- Dev mailing list - [shipwright-dev@lists.cncf.io](https://lists.cncf.io/g/shipwright-dev/join)
 
 ## Help us help you!
 Spend time framing questions and add links and resources.


### PR DESCRIPTION
# Changes

Follow up from mailing list update in #13, with corrections and squashes from #14.

Assisted-by: GitHub Copilot

/kind documentation

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [x] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/build/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
Correct mailing list and calendar links across the .github codebase.
```
