### PR TITLE
chore: make PR template sections fill-in-ready

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,20 +2,34 @@
 
 <!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->
 
-<!-- Describe your changes here- ideally you can get that description straight from
+<!-- Describe your changes here. Ideally you can get that description straight from
 your descriptive commit message(s)! -->
 
-<!-- If this PR fixes a GitHub issue, please mention it like so:
+# Related Issue
 
-Fixes #<insert issue number here>
+<!-- Link the GitHub issue this PR addresses. Use "Fixes" to auto-close the issue on merge,
+or "Related to" if the issue needs additional work. -->
 
--->
+Fixes #
+
+# Type of PR
+
+<!-- Replace with one of the following `/kind` commands so Prow applies the label:
+
+/kind bug
+/kind feature
+/kind cleanup
+/kind documentation
+
+See the [kind command docs](https://prow.k8s.io/command-help#kind) for more details. -->
+
+/kind your-label-here
 
 # Submitter Checklist
 
 - [ ] Includes tests if functionality changed/was added
 - [ ] Includes docs if changes are user-facing
-- [ ] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
+- [ ] Kind label has been set
 - [ ] Release notes block has been filled in, or marked NONE
 
 See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
@@ -23,30 +37,19 @@ for details on coding conventions, github and prow interactions, and the code re
 
 # Release Notes
 
-<!--
-Describe any user facing changes here, or delete this block.
+<!-- Describe any user-facing changes here, or mark as NONE.
 
-Examples of user facing changes:
+Examples of user-facing changes:
 - API changes
 - Bug fixes
 - Any changes in behavior
 - Changes requiring upgrade notices or deprecation warnings
 
-For pull requests with a release note:
+If this PR requires additional action from users switching to the new release,
+include the string "action required" (case insensitive) in the release note.
+
+If there are no user-facing changes, write NONE below. -->
 
 ```release-note
-Your release note here
+your release note here
 ```
-
-For pull requests that require additional action from users switching to the new release, include the string "action required" (case insensitive) in the release note:
-
-```release-note
-action required: your release note here
-```
-
-For pull requests that don't need to be mentioned at release time, use the `/release-note-none` Prow command to add the `release-note-none` label to the PR. You can also write the string "NONE" as a release note in your PR description:
-
-```release-note
-NONE
-```
--->


### PR DESCRIPTION
# Changes

<!-- 🎉🎉🎉 Thank you for the PR!!! 🎉🎉🎉 -->

<!-- Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! -->

<!-- If this PR fixes a GitHub issue, please mention it like so:

Fixes #<insert issue number here>

-->
Move actionable fields (Fixes #, /kind, release-note block) outside HTML comments so they're visible and ready to fill in. Add section headers and placeholders.

/kind cleanup

# Submitter Checklist

- [ ] Includes tests if functionality changed/was added
- [ ] Includes docs if changes are user-facing
- [x] [Set a kind label on this PR](https://prow.k8s.io/command-help#kind)
- [x] Release notes block has been filled in, or marked NONE

See [the contributor guide](https://github.com/shipwright-io/.github/blob/main/CONTRIBUTING.md)
for details on coding conventions, github and prow interactions, and the code review process.

# Release Notes

```release-note
NONE
```
